### PR TITLE
[#6] feat: update output format, add --no-header flag and use human friendly values

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,5 +1,26 @@
 use crate::FileSize;
 
+const KBYTES:u64 = 1024;
+const MBYTES:u64 = 1048576;
+const GBYTES:u64 = 1073741824;
+
+pub fn print_headers() {
+  println!("DISK\tBYTES\tPATH");
+}
+
 pub fn print_size(path: &std::path::PathBuf, calc: FileSize) {
-  println!("{:?}\tDisk: {:?}\tBytes: {:?}", path, calc.disk, calc.bytes);
+  let path_string = String::from(path.to_string_lossy());
+  println!("{}\t{}\t{}", human_size(calc.disk), human_size(calc.bytes), path_string);
+}
+
+fn human_size(size: u64) -> String {
+  if size > GBYTES {
+    return format!("{}G", size / GBYTES);
+  } else if size > MBYTES {
+    return format!("{}M", size / MBYTES);
+  } else if size > KBYTES {
+    return format!("{}K", size / KBYTES);
+  } else {
+    return format!("{}B", size);
+  }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,10 @@ use crate::size::{
     entry_size,
     FileSize
 };
-use crate::logger::print_size;
+use crate::logger::{
+    print_size,
+    print_headers
+};
 
 /// Search for a pattern in a file and display the lines that contain it.
 #[derive(Parser)]
@@ -17,12 +20,21 @@ struct Cli {
     /// The path to the file to read
     #[clap(parse(from_os_str))]
     path: std::path::PathBuf,
+
+    /// Hide the headers from the output
+    #[clap(long)]
+    no_header: bool,
 }
 
 fn main() -> std::io::Result<()> {
     let args = Cli::parse();
 
     let calc = entry_size(&args.path)?;
+
+    if !args.no_header {
+        print_headers()
+    }
+
     print_size(&args.path, calc);
 
     Ok(())


### PR DESCRIPTION
The main goal for `fu` is to provide a good developer experience. This tool provides a bit more information than `du` as it also includes the size in bytes. Based on that, this MR changes the CLI output to:

```
DISK   BYTES   PATH
4Kb    564     ./README.md
4Kb    300     ./test.md
```

Headers can also be removed with the `--no-header` argument.

Closes #6 