### PR TITLE
[#1] feat: use globs and paths with folders to list multiple files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,14 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "filesize",
+ "glob",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 clap = { version = "3.1.0", features = ["derive"] }
 filesize = { version = "0.2.0" }
+glob = { version = "0.3.0" }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,9 +8,10 @@ pub fn print_headers() {
   println!("DISK\tBYTES\tPATH");
 }
 
-pub fn print_size(path: &std::path::PathBuf, calc: FileSize) {
-  let path_string = String::from(path.to_string_lossy());
-  println!("{}\t{}\t{}", human_size(calc.disk), human_size(calc.bytes), path_string);
+pub fn print_size(results: &Vec<FileSize>) {
+  for result in results {
+    println!("{}\t{}\t{}", human_size(result.disk), human_size(result.bytes), result.path);
+  }
 }
 
 fn human_size(size: u64) -> String {

--- a/src/size.rs
+++ b/src/size.rs
@@ -6,7 +6,9 @@ pub struct FileSize {
   // Real bytes
   pub bytes: u64,
   // Size on disk
-  pub disk: u64
+  pub disk: u64,
+  // Path of the file
+  pub path: String
 }
 
 pub fn entry_size(path: &std::path::PathBuf) -> std::io::Result<FileSize> {
@@ -35,7 +37,8 @@ pub fn entry_size(path: &std::path::PathBuf) -> std::io::Result<FileSize> {
 
   let res = FileSize {
       bytes: acc,
-      disk: disk_acc
+      disk: disk_acc,
+      path: path.display().to_string()
   };
 
   Ok(res)


### PR DESCRIPTION
Allow the CLI to receive files, globs and folders and iterate the different paths. This required to change the main structure from `FileSize` to  `vec<FileSize>`. This will allow future improvements such as sorting and top.

```
> cargo run -- "./"
DISK    BYTES   PATH
364K    56K     .git
4K      263B    .github
4K      131B    .gitignore
8K      6K      Cargo.lock
4K      333B    Cargo.toml
12K     11K     LICENSE
4K      41B     README.md
12K     3K      src
106M    104M    target

> cargo run -- "."
DISK    BYTES   PATH
106M    104M    .
```

Closes #1 