### PR TITLE
[#3] feat: add colors to the output and the --no-colors option to disable it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "filesize"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +80,7 @@ name = "fu"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "colored",
  "filesize",
  "glob",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 clap = { version = "3.1.0", features = ["derive"] }
 filesize = { version = "0.2.0" }
 glob = { version = "0.3.0" }
+colored = { version = "2" }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,5 @@
 use crate::FileSize;
+use colored::*;
 
 const KBYTES:u64 = 1024;
 const MBYTES:u64 = 1048576;
@@ -8,9 +9,15 @@ pub fn print_headers() {
   println!("DISK\tBYTES\tPATH");
 }
 
-pub fn print_size(results: &Vec<FileSize>) {
+pub fn print_size(results: &Vec<FileSize>, no_colors: bool) {
   for result in results {
-    println!("{}\t{}\t{}", human_size(result.disk), human_size(result.bytes), result.path);
+    let output = format!("{}\t{}\t{}", human_size(result.disk), human_size(result.bytes), result.path);
+
+    if no_colors {
+      println!("{}", output);
+    } else {
+      println!("{}", colorize_size(output, result.bytes));
+    }
   }
 }
 
@@ -24,4 +31,22 @@ fn human_size(size: u64) -> String {
   } else {
     return format!("{}B", size);
   }
+}
+
+fn colorize_size(str: String, size: u64) -> String {
+  let colored_string: ColoredString;
+
+  if size > GBYTES {
+    colored_string = str.red();
+  } else if size > 512 * MBYTES {
+    colored_string = str.yellow();
+  } else if size > 128 * MBYTES {
+    colored_string = str.magenta();
+  } else if size > MBYTES {
+    colored_string = str.cyan();
+  } else {
+    colored_string = str.green();
+  }
+
+  return colored_string.to_string();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,10 @@ struct Cli {
     /// Hide the headers from the output
     #[clap(long)]
     no_header: bool,
+
+    /// Disable the colors in the output
+    #[clap(long)]
+    no_colors: bool,
 }
 
 fn main() -> std::io::Result<()> {
@@ -61,7 +65,7 @@ fn main() -> std::io::Result<()> {
         print_headers()
     }
 
-    print_size(&results);
+    print_size(&results, args.no_colors);
 
     Ok(())
 }


### PR DESCRIPTION
Add colors to the output by default. This behavior can be disabled using the `--no-colors` option:

<img width="561" alt="demo of the colors in the CLI. It shows different colors depending on the size" src="https://user-images.githubusercontent.com/4056725/155767229-1284f6ed-d2b8-4c14-9d5d-f2b0787c99d1.png">

Closes #3 