### PR TITLE
[#2] feat: add --sort to sort the list of entries based on bytes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ struct Cli {
     #[clap(parse(from_os_str))]
     path: std::path::PathBuf,
 
+    /// Sort the output based on the size
+    #[clap(long, short)]
+    sort: bool,
+
     /// Hide the headers from the output
     #[clap(long)]
     no_header: bool,
@@ -63,6 +67,10 @@ fn main() -> std::io::Result<()> {
 
     if !args.no_header {
         print_headers()
+    }
+
+    if args.sort {
+        results.sort_by(|a, b| b.bytes.cmp(&a.bytes));
     }
 
     print_size(&results, args.no_colors);


### PR DESCRIPTION
Add a new option to sort the list of entries based on the `bytes` size:

```
$ cargo run -- --sort ./
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/fu --sort ./`
DISK    BYTES   PATH
116M    114M    target
448K    66K     .git
12K     11K     LICENSE
8K      6K      Cargo.lock
12K     4K      src
4K      361B    Cargo.toml
4K      263B    .github
4K      131B    .gitignore
4K      41B     README.md
```