### PR TITLE
[#36] feat: bump version and add metadata to cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "fu"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "fu"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 authors = ["Angel M De Miguel <hi@angel.kiwi>"]
+description = "fu is a du alike CLI. It comes with a set of new features and a better output"
+readme = "README.md"
+license = "Apache-2.0"
+keywords = ["cli", "tool", "unix", "file", "filesize"]
+categories = ["command-line-utilities", "filesystem"]
+repository = "https://github.com/Angelmmiguel/fu/"
+exclude = [".*"]
+
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # fu
 
-`fu` is a `du` alike CLI. It comes with a set a new features and a better output. For example, it allows you to sort and limit the number of entries and provides a colorized output to highlight heaviest entries.
+`fu` is a `du` alike CLI. It comes with a set of new features and a better output. For example, it allows you to sort and limit the number of entries and provides a colorized output to highlight heaviest entries.
 
 ## Installation
 


### PR DESCRIPTION
Bump the version to v1.0.0 🥳. I also completed the metadata for Cargo and fixed the description in the README.md file.

Closes #36 