### PR TITLE
[#38] docs: use brew by default when installing fu on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ brew install Angelmmiguel/tap/fu
 <details>
   <summary>Install <code>fu</code> without brew</summary>
 
-To install `fu` without brew, run the following commands:
+Run the following commands to:
+
+1. Download the file from the GitHub releases page
+1. Uncompress it
+1. Remove the quarantine attribute from MacOS
+1. Move the CLI binary to /usr/local/bin
+1. Remove any remaining file
 
 ```
 curl -L \

--- a/README.md
+++ b/README.md
@@ -13,30 +13,37 @@
 
 ## Installation
 
-### Package managers
+### MacOS
 
-This work is still in progress. `fu` will be available in the different package managers :)
+To install it using view, run the following commands:
 
-### Manual
+```
+brew tap Angelmmiguel/tap
+brew install Angelmmiguel/tap/fu
+```
 
-#### MacOS
+<details>
+  <summary>Install `fu` without brew</summary>
 
-Run the following commands in a terminal:
+To install `fu` without brew, run the following commands:
 
 ```
 curl -L \
   https://github.com/Angelmmiguel/fu/releases/latest/download/fu-x86_64-apple-darwin.tar.gz \
     -o /tmp/fu-x86_64-apple-darwin.tar.gz && \
   tar -xvf /tmp/fu-x86_64-apple-darwin.tar.gz -C /tmp && \
+  xattr -d com.apple.quarantine /tmp/fu-x86_64-apple-darwin/fu && \
   mv /tmp/fu-x86_64-apple-darwin/fu /usr/local/bin && \
   rm -r /tmp/fu-x86_64-apple-darwin.tar.gz /tmp/fu-x86_64-apple-darwin
 ```
 
-> NOTE: MacOS may block `fu` CLI due to unknown signature. You can allow it by accessing the _Security and Privacy_ system preference panel and clicking on the _Allow anyway_ button.
+The `xattr` call is required because downloaded binaries are marked as "quarantine" by MacOS. In addition to that, the system may block `fu` CLI due to unknown signature. You can allow it by accessing the _Security and Privacy_ system preference panel and clicking on the _Allow anyway_ button.`
 
 This will install the `fu` CLI in the `/usr/local/bin` folder.
 
-#### Linux
+</details>
+
+### Linux
 
 Run the following commands in a terminal:
 
@@ -51,7 +58,7 @@ curl -L \
 
 This will install the `fu` CLI in the `/usr/local/bin` folder.
 
-#### Windows
+### Windows
 
 For Windows, please follow the next steps:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install Angelmmiguel/tap/fu
 ```
 
 <details>
-  <summary>Install `fu` without brew</summary>
+  <summary>Install <code>fu</code> without brew</summary>
 
 To install `fu` without brew, run the following commands:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curl -L \
   rm -r /tmp/fu-x86_64-apple-darwin.tar.gz /tmp/fu-x86_64-apple-darwin
 ```
 
-The `xattr` call is required because downloaded binaries are marked as "quarantine" by MacOS. In addition to that, the system may block `fu` CLI due to unknown signature. You can allow it by accessing the _Security and Privacy_ system preference panel and clicking on the _Allow anyway_ button.`
+The `xattr` call is required because downloaded binaries are marked as "quarantine" by MacOS. In addition to that, the system may block `fu` CLI due to unknown signature. You can allow it by accessing the _Security and Privacy_ system preference panel and clicking on the _Allow anyway_ button.
 
 This will install the `fu` CLI in the `/usr/local/bin` folder.
 


### PR DESCRIPTION
Update the README.md information to install `fu` on MacOS using brew by default. These command uses the formula I created on Angelmmiguel/homebrew-tap repo.

Apart from that, I will keep the old way to install the CLI as an expandable item.

Closes #38 